### PR TITLE
 Added automatic replacement

### DIFF
--- a/RingingBloom/Windows/BNKEditor.xaml
+++ b/RingingBloom/Windows/BNKEditor.xaml
@@ -36,6 +36,7 @@
             <MenuItem Header="Import Wems" Click="Import_Wems"/>
             <MenuItem Header="Export Wems" Click="Export_Wems"/>
             <MenuItem Header="Mass Replace" Click="MassReplace"/>
+            <MenuItem Header="Automatic Replace" Click="AutomaticReplace"/>
         </ContextMenu>
         <local:ChunkSelector x:Key="ChunkSelect" BKHDTemplate="{StaticResource BKHD}" WemTemplate="{StaticResource Wem}"/>
     </Window.Resources>

--- a/RingingBloom/Windows/BNKEditor.xaml.cs
+++ b/RingingBloom/Windows/BNKEditor.xaml.cs
@@ -115,6 +115,72 @@ namespace RingingBloom.Windows
                 PopulateTreeView(false);
             }
         }
+
+        private void AutomaticReplace(object sender, RoutedEventArgs e)
+        {
+            if (nbnk == null || nbnk.DataIndex == null || nbnk.DataIndex.wemList.Count == 0)
+            {
+                MessageBox.Show("0 Bnk Files Loaded");
+                return;
+            }
+
+            var dialog = new OpenFileDialog();
+            if (ImportPath != null)
+            {
+                dialog.InitialDirectory = ImportPath;
+            }
+            dialog.CheckFileExists = false;
+            dialog.FileName = "The folder requires the .wem files to have the same names as the IDs";
+
+            if (dialog.ShowDialog() != true)
+            {
+                return;
+            }
+
+            string folderPath = System.IO.Path.GetDirectoryName(dialog.FileName);
+
+            List<uint> replacedIds = new List<uint>();
+            int totalReplaced = 0;
+
+            for (int i = 0; i < nbnk.DataIndex.wemList.Count; i++)
+            {
+                uint wemId = nbnk.DataIndex.wemList[i].id;
+
+                // To verify a corresponding ID.
+                string filePath = System.IO.Path.Combine(folderPath, wemId.ToString() + ".wem");
+
+                if (File.Exists(filePath))
+                {
+                    try
+                    {
+                        uint newId = nbnk.DataIndex.wemList[i].id;
+                        Wem newWem = new Wem(System.IO.Path.GetFileName(filePath), newId.ToString(), new BinaryReader(File.Open(filePath, FileMode.Open)));
+                        nbnk.DataIndex.wemList[i] = newWem;
+
+                        replacedIds.Add(wemId);
+                        totalReplaced++;
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show($"Error replacing {wemId}.wem: {ex.Message}");
+                    }
+                }
+            }
+
+            PopulateTreeView(true);
+
+            if (totalReplaced > 0)
+            {
+                string IDreplaced = string.Join(", ", replacedIds);
+                MessageBox.Show($"{totalReplaced} Wem files replaced\n\nReplaced ID's: {IDreplaced}",
+                    "Done", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else
+            {
+                MessageBox.Show("No .wem files were replaced. Check if the filenames match the .wem IDs in the BNK.");
+            }
+        }
+
         public void ExportBNK(object sender, RoutedEventArgs e)
         {
             SaveFileDialog saveFile = new SaveFileDialog();

--- a/RingingBloom/Windows/NPCKEditor.xaml
+++ b/RingingBloom/Windows/NPCKEditor.xaml
@@ -17,6 +17,7 @@
                 <MenuItem Header="Export" Click="ExportNPCK"/>
                 <MenuItem Header="Replace Wem" Click="Replace_Wem"/>
                 <MenuItem Header="Mass Replace" Click="Mass_Replace"/>
+                <MenuItem Header="Automatic Replace" Click="AutomaticReplace"/>
                 <MenuItem Header="Import Wems" Click="Import_Wems"/>
                 <MenuItem Header="Export Wems" Click="Export_Wems"/>
                 <MenuItem Header="Delete Wem" Click="Delete_Wem"/>

--- a/RingingBloom/Windows/NPCKEditor.xaml.cs
+++ b/RingingBloom/Windows/NPCKEditor.xaml.cs
@@ -294,6 +294,68 @@ namespace RingingBloom.Windows
 
         }
 
+        private void AutomaticReplace(object sender, RoutedEventArgs e)
+        {
+            if (viewModel.npck == null)
+            {
+                MessageBox.Show("PCK not loaded.");
+                return;
+            }
+
+            var dialog = new OpenFileDialog();
+            if (ImportPath != null)
+            {
+                dialog.InitialDirectory = ImportPath;
+            }
+            dialog.CheckFileExists = false;
+            dialog.FileName = "The folder requires the .wem files to have the same names as the IDs";
+
+            if (dialog.ShowDialog() != true)
+            {
+                return;
+            }
+
+            string folderPath = System.IO.Path.GetDirectoryName(dialog.FileName);
+
+            List<uint> replacedIds = new List<uint>();
+            int totalReplaced = 0;
+
+            for (int i = 0; i < viewModel.npck.WemList.Count; i++)
+            {
+                uint wemId = viewModel.npck.WemList[i].id;
+
+                string filePath = System.IO.Path.Combine(folderPath, wemId.ToString() + ".wem");
+
+                if (File.Exists(filePath))
+                {
+                    try
+                    {
+                        Wem newWem = HelperFunctions.MakeWems(filePath, HelperFunctions.OpenFile(filePath));
+                        viewModel.ReplaceWem(newWem, i);
+
+                        replacedIds.Add(wemId);
+                        totalReplaced++;
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show($"Error replacing {wemId}.wem: {ex.Message}");
+                    }
+                }
+            }
+
+            if (totalReplaced > 0)
+            {
+                string IDreplaced = string.Join(", ", replacedIds);
+                MessageBox.Show($"{totalReplaced} Wem files replaced\n\nReplaced ID's: {IDreplaced}",
+                    "Done", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else
+            {
+                MessageBox.Show("No .wem files were replaced. Check if the filenames match the .wem IDs in the PCK.");
+            }
+        }
+
+
         private void HelpMenu(object sender, RoutedEventArgs e)
         {
             MessageBox.Show("NPCK Editor: for editing WWise Package files.\n\n" +


### PR DESCRIPTION
Now, both in the BNK Editor and PCK Editor, an option to replace .wem files automatically is available, as long as a folder with .wem files that have the same name as their own IDs is selected